### PR TITLE
Revamped how Lavaplayer should function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
         <dependency>
             <groupId>com.github.austinv11</groupId>
             <artifactId>Discord4J</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.sedmelluq</groupId>
             <artifactId>lavaplayer</artifactId>
-            <version>1.2.36</version>
+            <version>1.2.42</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/github/decyg/CommandHandler.java
+++ b/src/main/java/com/github/decyg/CommandHandler.java
@@ -1,6 +1,7 @@
 package com.github.decyg;
 
 import com.github.decyg.lavaplayer.GuildMusicManager;
+import com.github.decyg.lavaplayer.TrackScheduler;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -15,7 +16,6 @@ import sx.blah.discord.handle.obj.IGuild;
 import sx.blah.discord.handle.obj.IVoiceChannel;
 import sx.blah.discord.util.EmbedBuilder;
 import sx.blah.discord.util.RequestBuffer;
-import sx.blah.discord.util.audio.AudioPlayer;
 
 import java.util.*;
 
@@ -56,9 +56,9 @@ public class CommandHandler {
             if(botVoiceChannel == null)
                 return;
 
-            AudioPlayer audioP = AudioPlayer.getAudioPlayerForGuild(event.getGuild());
-
-            audioP.clear();
+            TrackScheduler scheduler = getGuildAudioPlayer(event.getGuild()).getScheduler();
+            scheduler.getQueue().clear();
+            scheduler.nextTrack();
 
             botVoiceChannel.leave();
 
@@ -176,12 +176,12 @@ public class CommandHandler {
 
     private static void play(GuildMusicManager musicManager, AudioTrack track) {
 
-        musicManager.scheduler.queue(track);
+        musicManager.getScheduler().queue(track);
     }
 
     private static void skipTrack(IChannel channel) {
         GuildMusicManager musicManager = getGuildAudioPlayer(channel.getGuild());
-        musicManager.scheduler.nextTrack();
+        musicManager.getScheduler().nextTrack();
 
         BotUtils.sendMessage(channel, "Skipped to next track.");
     }

--- a/src/main/java/com/github/decyg/lavaplayer/GuildMusicManager.java
+++ b/src/main/java/com/github/decyg/lavaplayer/GuildMusicManager.java
@@ -2,19 +2,15 @@ package com.github.decyg.lavaplayer;
 
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.player.event.AudioEventListener;
 
 /**
  * Holder for both the player and a track scheduler for one guild.
  */
 public class GuildMusicManager {
-  /**
-   * Audio player for the guild.
-   */
-  public final AudioPlayer player;
-  /**
-   * Track scheduler for the player.
-   */
-  public final TrackScheduler scheduler;
+  private final AudioPlayer player;
+  private final AudioProvider provider;
+  private final TrackScheduler scheduler;
 
   /**
    * Creates a player and a track scheduler.
@@ -22,14 +18,35 @@ public class GuildMusicManager {
    */
   public GuildMusicManager(AudioPlayerManager manager) {
     player = manager.createPlayer();
+    provider = new AudioProvider(player);
     scheduler = new TrackScheduler(player);
-    player.addListener(scheduler);
+  }
+
+  /**
+   * Adds a listener to be registered for audio events.
+   */
+  public void addAudioListener(AudioEventListener listener) {
+    player.addListener(listener);
+  }
+
+  /**
+   * Removes a listener that was registered for audio events.
+   */
+  public void removeAudioListener(AudioEventListener listener) {
+    player.removeListener(listener);
+  }
+
+  /**
+   * @return The scheduler for AudioTracks.
+   */
+  public TrackScheduler getScheduler() {
+    return this.scheduler;
   }
 
   /**
    * @return Wrapper around AudioPlayer to use it as an AudioSendHandler.
    */
   public AudioProvider getAudioProvider() {
-    return new AudioProvider(player);
+    return provider;
   }
 }

--- a/src/main/java/com/github/decyg/lavaplayer/TrackScheduler.java
+++ b/src/main/java/com/github/decyg/lavaplayer/TrackScheduler.java
@@ -70,6 +70,9 @@ public class TrackScheduler {
   /**
    * Returns the queue for this scheduler. Adding to the head of the queue (index 0) does not automatically
    * cause it to start playing immediately. The returned collection is thread-safe and can be modified.
+   *
+   * @apiNote To iterate over this queue, use a synchronized block. For example:
+   * {@code synchronize (getQueue()) { // iteration code } }
    */
   public List<AudioTrack> getQueue() {
     return this.queue;

--- a/src/main/java/com/github/decyg/lavaplayer/TrackScheduler.java
+++ b/src/main/java/com/github/decyg/lavaplayer/TrackScheduler.java
@@ -5,22 +5,34 @@ import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * This class schedules tracks for the audio player. It contains the queue of tracks.
  */
-public class TrackScheduler extends AudioEventAdapter {
+public class TrackScheduler {
+  private final List<AudioTrack> queue;
   private final AudioPlayer player;
-  private final BlockingQueue<AudioTrack> queue;
 
-  /**
-   * @param player The audio player this scheduler uses
-   */
   public TrackScheduler(AudioPlayer player) {
+    // Because we will be removing from the "head" of the queue frequently, a LinkedList is a better implementation
+    // since all elements won't have to be shifted after removing. Additionally, choosing to add in between the queue
+    // will similarly not cause many elements to shift and wil only require a couple of node changes.
+    queue = Collections.synchronizedList(new LinkedList<>());
     this.player = player;
-    this.queue = new LinkedBlockingQueue<>();
+
+    // For encapsulation, keep the listener anonymous.
+    player.addListener(new AudioEventAdapter() {
+      @Override
+      public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
+        // Only start the next track if the end reason is suitable for it (FINISHED or LOAD_FAILED)
+        if(endReason.mayStartNext) {
+          nextTrack();
+        }
+      }
+    });
   }
 
   /**
@@ -28,29 +40,38 @@ public class TrackScheduler extends AudioEventAdapter {
    *
    * @param track The track to play or add to queue.
    */
-  public void queue(AudioTrack track) {
+  public synchronized boolean queue(AudioTrack track) {
     // Calling startTrack with the noInterrupt set to true will start the track only if nothing is currently playing. If
     // something is playing, it returns false and does nothing. In that case the player was already playing so this
     // track goes to the queue instead.
-    if (!player.startTrack(track, true)) {
-      queue.offer(track);
+    boolean playing = player.startTrack(track, true);
+
+    if(!playing) {
+      queue.add(track);
     }
+
+    return playing;
   }
 
   /**
-   * Start the next track, stopping the current one if it is playing.
+   * Starts the next track, stopping the current one if it is playing.
+   * @return The track that was stopped, null if there wasn't anything playing
    */
-  public void nextTrack() {
+  public synchronized AudioTrack nextTrack() {
+    AudioTrack currentTrack = player.getPlayingTrack();
+    AudioTrack nextTrack = queue.isEmpty() ? null : queue.remove(0);
+
     // Start the next track, regardless of if something is already playing or not. In case queue was empty, we are
     // giving null to startTrack, which is a valid argument and will simply stop the player.
-    player.startTrack(queue.poll(), false);
+    player.startTrack(nextTrack, false);
+    return currentTrack;
   }
 
-  @Override
-  public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
-    // Only start the next track if the end reason is suitable for it (FINISHED or LOAD_FAILED)
-    if (endReason.mayStartNext) {
-      nextTrack();
-    }
+  /**
+   * Returns the queue for this scheduler. Adding to the head of the queue (index 0) does not automatically
+   * cause it to start playing immediately. The returned collection is thread-safe and can be modified.
+   */
+  public List<AudioTrack> getQueue() {
+    return this.queue;
   }
 }


### PR DESCRIPTION
The Lavaplayer example is flawed in several ways. I have fixed it.

# Changes
1. Fixed clearing the queue. Previously it was literally clearing the wrong queue and just flat out didn't work. That has been fixed.
2. Changed entirely what the functionality of `TrackScheduler` should do. `AudioPlayer` is, sort of, badly designed. It provides functionality that isn't to the role of playing audio and thus leaking that potential behavior is bad. To combat this, `TrackScheduler` is designated the role of...well...handling tracks. In terms of the changes I have done, nothing has been changed in terms of functionality, but it's worth noting that if users want to change volume, pause/unpause, methods should be added here for that.
3. In addition to 2, the only other functionality that is left would be closing the player and adding listeners. That is what `GuildMusicManager` can do. Because of 3 and 2, `AudioPlayer` should never be seen outside of the `lavaplayer` package.
4. Changed how the queue works. Previously, the way to manage the queue was highly restrictive. You couldn't iterate over it, you couldn't shuffle it, you couldn't add or remove from the middle, etc. Now you can. Yay.
5. Updated dependencies.